### PR TITLE
Adjust init to reference department_id and remove class references

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ class Department:
 
     @name.setter
     def name(self, name):
-        if isinstance(name, str) and len(name) > 0:
+        if isinstance(name, str) and len(name):
             self._name = name
         else:
             raise ValueError(
@@ -87,7 +87,7 @@ class Department:
 
     @location.setter
     def location(self, location):
-        if isinstance(location, str) and len(location) > 0:
+        if isinstance(location, str) and len(location):
             self._location = location
         else:
             raise ValueError(
@@ -113,11 +113,11 @@ class Employee:
     # Dictionary of objects saved to the database.
     all = {}
 
-    def __init__(self, name, job_title, department, id=None):
+    def __init__(self, name, job_title, department_id, id=None):
         self.id = id
         self.name = name
         self.job_title = job_title
-        self.department = department
+        self.department_id = department_id
 
     def __repr__(self):
         return (
@@ -131,7 +131,7 @@ class Employee:
 
     @name.setter
     def name(self, name):
-        if isinstance(name, str) and len(name) > 0:
+        if isinstance(name, str) and len(name):
             self._name = name
         else:
             raise ValueError(
@@ -144,7 +144,7 @@ class Employee:
 
     @job_title.setter
     def job_title(self, job_title):
-        if isinstance(job_title, str) and len(job_title) > 0:
+        if isinstance(job_title, str) and len(job_title):
             self._job_title = job_title
         else:
             raise ValueError(
@@ -235,7 +235,7 @@ class Department:
 
     @name.setter
     def name(self, name):
-        if isinstance(name, str) and len(name) > 0:
+        if isinstance(name, str) and len(name):
             self._name = name
         else:
             raise ValueError(
@@ -248,7 +248,7 @@ class Department:
 
     @location.setter
     def location(self, location):
-        if isinstance(location, str) and len(location) > 0:
+        if isinstance(location, str) and len(location):
             self._location = location
         else:
             raise ValueError(
@@ -289,12 +289,12 @@ class Department:
         CONN.commit()
 
         self.id = CURSOR.lastrowid
-        Department.all[self.id] = self
+        type(self).all[self.id] = self
 
     @classmethod
     def create(cls, name, location):
         """ Initialize a new Department instance and save the object to the database """
-        department = Department(name, location)
+        department = cls(name, location)
         department.save()
         return department
 
@@ -323,7 +323,7 @@ class Department:
         """Return a Department object having the attribute values from the table row."""
 
         # Check the dictionary for an existing instance using the row's primary key
-        department = Department.all.get(row[0])
+        department = cls.all.get(row[0])
         if department:
             # ensure attributes match row values in case local instance was modified
             department.name = row[1]
@@ -332,7 +332,7 @@ class Department:
         else:
             department = cls(row[1], row[2])
             department.id = row[0]
-            Department.all[department.id] = department
+            cls.all[department.id] = department
         return department
 
     @classmethod
@@ -413,7 +413,7 @@ class Employee:
 
     @name.setter
     def name(self, name):
-        if isinstance(name, str) and len(name) > 0:
+        if isinstance(name, str) and len(name):
             self._name = name
         else:
             raise ValueError(
@@ -426,7 +426,7 @@ class Employee:
 
     @job_title.setter
     def job_title(self, job_title):
-        if isinstance(job_title, str) and len(job_title) > 0:
+        if isinstance(job_title, str) and len(job_title):
             self._job_title = job_title
         else:
             raise ValueError(
@@ -481,7 +481,7 @@ class Employee:
         CONN.commit()
 
         self.id = CURSOR.lastrowid
-        Employee.all[self.id] = self
+        type(self).all[self.id] = self
 
     def update(self):
         """Update the table row corresponding to the current Employee instance."""
@@ -507,7 +507,7 @@ class Employee:
     @classmethod
     def create(cls, name, job_title, department_id):
         """ Initialize a new Employee instance and save the object to the database """
-        employee = Employee(name, job_title, department_id)
+        employee = cls(name, job_title, department_id)
         employee.save()
         return employee
 
@@ -516,7 +516,7 @@ class Employee:
         """Return an Employee object having the attribute values from the table row."""
 
         # Check the dictionary for  existing instance using the row's primary key
-        employee = Employee.all.get(row[0])
+        employee = cls.all.get(row[0])
         if employee:
             # ensure attributes match row values in case local instance was modified
             employee.name = row[1]
@@ -526,7 +526,7 @@ class Employee:
         else:
             employee = cls(row[1], row[2], row[3])
             employee.id = row[0]
-            Employee.all[employee.id] = employee
+            cls.all[employee.id] = employee
         return employee
 
     @classmethod

--- a/lib/department.py
+++ b/lib/department.py
@@ -48,12 +48,12 @@ class Department:
         CONN.commit()
 
         self.id = CURSOR.lastrowid
-        Department.all[self.id] = self
+        type(self).all[self.id] = self
 
     @classmethod
     def create(cls, name, location):
         """ Initialize a new Department instance and save the object to the database """
-        department = Department(name, location)
+        department = cls(name, location)
         department.save()
         return department
 
@@ -76,13 +76,15 @@ class Department:
 
         CURSOR.execute(sql, (self.id,))
         CONN.commit()
+        # remove object from local dictionary
+        del type(self).all[self.id]
 
     @classmethod
     def instance_from_db(cls, row):
         """Return a Department object having the attribute values from the table row."""
 
         # Check the dictionary for an existing instance using the row's primary key
-        department = Department.all.get(row[0])
+        department = cls.all.get(row[0])
         if department:
             # ensure attributes match row values in case local instance was modified
             department.name = row[1]
@@ -91,7 +93,7 @@ class Department:
         else:
             department = cls(row[1], row[2])
             department.id = row[0]
-            Department.all[department.id] = department
+            cls.all[department.id] = department
         return department
 
     @classmethod

--- a/lib/employee.py
+++ b/lib/employee.py
@@ -3,7 +3,6 @@ from department import Department
 
 
 class Employee:
-
     # Dictionary of objects saved to the database.
     all = {}
 
@@ -15,13 +14,13 @@ class Employee:
 
     def __repr__(self):
         return (
-            f"<Employee {self.id}: {self.name}, {self.job_title}, " +
-            f"Department ID: {self.department_id}>"
+            f"<Employee {self.id}: {self.name}, {self.job_title}, "
+            + f"Department ID: {self.department_id}>"
         )
-   
+
     @classmethod
     def create_table(cls):
-        """ Create a new table to persist the attributes of Employee instances """
+        """Create a new table to persist the attributes of Employee instances"""
         sql = """
             CREATE TABLE IF NOT EXISTS employees (
             id INTEGER PRIMARY KEY,
@@ -35,7 +34,7 @@ class Employee:
 
     @classmethod
     def drop_table(cls):
-        """ Drop the table that persists Employee instances """
+        """Drop the table that persists Employee instances"""
         sql = """
             DROP TABLE IF EXISTS employees;
         """
@@ -43,7 +42,7 @@ class Employee:
         CONN.commit()
 
     def save(self):
-        """ Insert a new row with the name, job title, and department id values of the current Employee object.
+        """Insert a new row with the name, job title, and department id values of the current Employee object.
         Update object id attribute using the primary key value of new row.
         Save the object in local dictionary using table row's PK as dictionary key"""
         sql = """
@@ -55,7 +54,7 @@ class Employee:
         CONN.commit()
 
         self.id = CURSOR.lastrowid
-        Employee.all[self.id] = self
+        type(self).all[self.id] = self
 
     def update(self):
         """Update the table row corresponding to the current Employee instance."""
@@ -64,8 +63,7 @@ class Employee:
             SET name = ?, job_title = ?, department_id = ?
             WHERE id = ?
         """
-        CURSOR.execute(sql, (self.name, self.job_title,
-                             self.department_id, self.id))
+        CURSOR.execute(sql, (self.name, self.job_title, self.department_id, self.id))
         CONN.commit()
 
     def delete(self):
@@ -77,11 +75,13 @@ class Employee:
 
         CURSOR.execute(sql, (self.id,))
         CONN.commit()
+        # remove object from local dictionary
+        del type(self).all[self.id]
 
     @classmethod
     def create(cls, name, job_title, department_id):
-        """ Initialize a new Employee instance and save the object to the database """
-        employee = Employee(name, job_title, department_id)
+        """Initialize a new Employee instance and save the object to the database"""
+        employee = cls(name, job_title, department_id)
         employee.save()
         return employee
 
@@ -90,7 +90,7 @@ class Employee:
         """Return an Employee object having the attribute values from the table row."""
 
         # Check the dictionary for  existing instance using the row's primary key
-        employee = Employee.all.get(row[0])
+        employee = cls.all.get(row[0])
         if employee:
             # ensure attributes match row values in case local instance was modified
             employee.name = row[1]
@@ -100,7 +100,7 @@ class Employee:
         else:
             employee = cls(row[1], row[2], row[3])
             employee.id = row[0]
-            Employee.all[employee.id] = employee
+            cls.all[employee.id] = employee
         return employee
 
     @classmethod


### PR DESCRIPTION
Remove class references from both class and instance methods, adjust the README to fix the issue with the Employee init, remove unnecessary comparison operator from decorators setter method and remove instance from dict upon deletion from db.